### PR TITLE
release: v0.2.1 — multi-monitor fix, adaptive polling, bug fixes

### DIFF
--- a/TokiMonitor.xcodeproj/project.pbxproj
+++ b/TokiMonitor.xcodeproj/project.pbxproj
@@ -29,16 +29,13 @@
 		2B5BAB785ED50C752A107E13 /* CostChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADB19DAAAC2A8BD63CB59C8 /* CostChart.swift */; };
 		2C3F97F7C70F8029872F46B7 /* TablePanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA03537C2F0CAF1D37B5252 /* TablePanelView.swift */; };
 		2C5565559581A5B645B3349C /* ProviderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA89702E4E5B1108842AA475 /* ProviderRegistry.swift */; };
-		A1B2C3D4E5F60718091A2B3C /* ModelPricing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6071809A1B2C3D4E5F6 /* ModelPricing.swift */; };
 		2FD39BD3817670D06BE68CEF /* ProviderRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507FA6EFF17810ED320DE318 /* ProviderRegistryTests.swift */; };
 		30E96B62CCA9D6694DCED0BE /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA30A3E71C0D0B2A1682750 /* SettingsWindowController.swift */; };
-		3332CEA99B4EBD15C418D910 /* run_05.png in Resources */ = {isa = PBXBuildFile; fileRef = 427ED7AB9807D9DD887EBD92 /* run_05.png */; };
+		3574E94BBA0BB4EA83DB6F40 /* Animations in Resources */ = {isa = PBXBuildFile; fileRef = 4C9D9972B2FA620BD19C947D /* Animations */; };
 		35C19F7105186D30872BA9AA /* PanelResizeHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA1754431AB65F03A7CBB13 /* PanelResizeHandle.swift */; };
-		39DF561B00E6866F5F760219 /* run_01.png in Resources */ = {isa = PBXBuildFile; fileRef = 4921C5A600FE4FF1E20BB12C /* run_01.png */; };
 		3A08C6B2401417D71EEA07F6 /* AnnotationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10582F33BB2A12E45F2A6BB /* AnnotationStore.swift */; };
 		3B53DEBD38340CE172E5019E /* MenuBarSettingsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4771B8F6125461E69C2CFE8 /* MenuBarSettingsPane.swift */; };
 		3C67B974F8F903F27F8D9F62 /* TokiMonitorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A83167497A1EE039A2B2494 /* TokiMonitorApp.swift */; };
-		3D7278E964B217624992A688 /* run_02.png in Resources */ = {isa = PBXBuildFile; fileRef = 93DBD83CDA2E2CEAB600F3BB /* run_02.png */; };
 		3DA3BA25D0968CA27E13ECE3 /* PanelDataExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61E686B7BA4F794ABE3C325 /* PanelDataExtractor.swift */; };
 		40CC603230947A99EB36F064 /* TokenAggregatorLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F74A465DDBF407B395F8AA /* TokenAggregatorLogicTests.swift */; };
 		417DA2C685E33E4F4E375DE4 /* PlaylistManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9953C511BFF1317C46D027D6 /* PlaylistManager.swift */; };
@@ -50,7 +47,6 @@
 		4DF008865414431174E7637E /* frame_05.png in Resources */ = {isa = PBXBuildFile; fileRef = C89A62671E6B8235B289897B /* frame_05.png */; };
 		4E185ECB80CEBAD70B4DD71F /* TokiEventStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A07540C3665358D10E114C /* TokiEventStream.swift */; };
 		4F0393586E478CF6F96F5B8D /* TimeSeriesGapFiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B785BB7AAB222C1088257256 /* TimeSeriesGapFiller.swift */; };
-		4FBBB2CEEBB26DDD1E82279C /* run_06.png in Resources */ = {isa = PBXBuildFile; fileRef = 607D77AED90E38601083C087 /* run_06.png */; };
 		502EEB38E57AB5717C4E6301 /* AnimationTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B17BA2BAF5855E537D1C1D0 /* AnimationTheme.swift */; };
 		52E309697FFE7308176F30EA /* GlassWorkaround.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10835A353F20C9BFA10795A1 /* GlassWorkaround.swift */; };
 		54433E5F9B3BE800677C5ECE /* SyncSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1837716A9BFD555E0A36B8A /* SyncSettingsView.swift */; };
@@ -64,7 +60,6 @@
 		65AA1C3426510B47ECEC2529 /* TimeSeriesModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A285CEF82274757C8A327142 /* TimeSeriesModels.swift */; };
 		669753CC9D61AB01C3F2547C /* VersionCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4C36A205DFC4F7DA9CD54A9 /* VersionCompatibility.swift */; };
 		69295AAE29A8D4FB6FBD903E /* TokenUsageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196E4E973580CB5B1A9B79FA /* TokenUsageModel.swift */; };
-		6BEC823E63A5B721FA4F154E /* theme.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C34A2D8996268241E877C53 /* theme.json */; };
 		6FFE0E1FB8E6C0990D3D1F7E /* AlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5EDD636F883E05C6E56C0C /* AlertManager.swift */; };
 		789F755BF45FCF87C7EF5C9F /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB89E56D927ABD7289F04084 /* SettingsView.swift */; };
 		7A3A92BC03EC47C681AC5E76 /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6576E137DF2FCFE73BE66102 /* DesignSystem.swift */; };
@@ -83,7 +78,6 @@
 		A5A0153D1AF63F11B4BE8133 /* TokiEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4247163632AC4A7FF3582B /* TokiEvent.swift */; };
 		A673F7E773850A93FABC17EE /* DashboardToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FB627746EE1DECBC2CBA2C /* DashboardToolbar.swift */; };
 		AE7388FE3592A7411AC81393 /* VersionHistorySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E478EB5C5691C2D6693F41 /* VersionHistorySheet.swift */; };
-		B1BEE5085C8777D9EF876A04 /* run_04.png in Resources */ = {isa = PBXBuildFile; fileRef = A3009FD2313EE41259DC8037 /* run_04.png */; };
 		B1D657C2EEDCA875C6490B61 /* SyncClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8917E556BB8BA674083AA0D /* SyncClient.swift */; };
 		B40444463A7E8FAB10625282 /* TimeRangePickerPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AEF7A2555230D2AF60A455 /* TimeRangePickerPopover.swift */; };
 		B87610314D4693D729AF3D54 /* AnimationStateMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24A89C84AD804E6D14E648F /* AnimationStateMapperTests.swift */; };
@@ -99,12 +93,11 @@
 		C9B1B05E770D61B3E9D3108E /* PanelEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E131E3756214B21A8B8654B1 /* PanelEditorView.swift */; };
 		CA53B87359FD3833598A2E5C /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27DDC52F74B0CB31A48BB7CE /* SparklineView.swift */; };
 		CA9C7AA78EF38E315FCBB43D /* frame_03.png in Resources */ = {isa = PBXBuildFile; fileRef = C060811529815B293611230B /* frame_03.png */; };
-		D1CEF03ED06D451B4D02A7D9 /* run_00.png in Resources */ = {isa = PBXBuildFile; fileRef = 9F47734BE06CE332F023528D /* run_00.png */; };
 		D3B34FF52E62F5D2E45480DC /* CharacterAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA93FB660B4398E6A806FC3 /* CharacterAnimationView.swift */; };
+		D9AED0BD0367047F1034D688 /* ModelPricing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7368908C5687B4CB8281CE2C /* ModelPricing.swift */; };
 		DCECAC1B3A4EEA97415FC579 /* AboutPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3489A041D9F174427EDFF7ED /* AboutPane.swift */; };
 		DDE1EB2EC7A1FBCF494362FC /* AddPanelPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC45E4DF1A7CDBFB1E6D3C49 /* AddPanelPopover.swift */; };
 		DF1E83D524D2E5D935082DA9 /* CodexUsageClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5FAA4A976ADB25E1195013F /* CodexUsageClient.swift */; };
-		E0AAF320A888951229785FE1 /* run_03.png in Resources */ = {isa = PBXBuildFile; fileRef = 660A4FE97F12851611B35159 /* run_03.png */; };
 		E5113FB852A0035ADFB20C19 /* BarChartPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB11444FDF44AA3CB147AA1 /* BarChartPanelView.swift */; };
 		E9C97C704F48EF0280E0ADD0 /* ConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0103BDEAC6066E0274029149 /* ConnectionManager.swift */; };
 		EBEAD3D481833720FA9F9E19 /* TokiEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755C88AB0D9EE0E7EDC3CDAE /* TokiEventStreamTests.swift */; };
@@ -159,14 +152,13 @@
 		3BDCB8700F8EE06B7CB0AC2F /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
 		3EED40448CCAA9BDD9E5EE7E /* TimeSeriesPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSeriesPanelView.swift; sourceTree = "<group>"; };
 		4215CB67D3CB129464800547 /* TokiMonitor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TokiMonitor.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		427ED7AB9807D9DD887EBD92 /* run_05.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = run_05.png; sourceTree = "<group>"; };
 		42E478EB5C5691C2D6693F41 /* VersionHistorySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionHistorySheet.swift; sourceTree = "<group>"; };
 		472F2F7AB9F295A874844E6D /* ConnectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionManagerTests.swift; sourceTree = "<group>"; };
 		476DECAE0D1683A1642FEC9A /* GeneralSettingsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsPane.swift; sourceTree = "<group>"; };
-		4921C5A600FE4FF1E20BB12C /* run_01.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = run_01.png; sourceTree = "<group>"; };
 		4A62B05BBA5579FF67EA1B8D /* PieChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieChartView.swift; sourceTree = "<group>"; };
 		4AB11444FDF44AA3CB147AA1 /* BarChartPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarChartPanelView.swift; sourceTree = "<group>"; };
 		4BDA0DC9C4300E5F7B2E3F2A /* SyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManager.swift; sourceTree = "<group>"; };
+		4C9D9972B2FA620BD19C947D /* Animations */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Animations; path = TokiMonitor/Resources/Animations; sourceTree = SOURCE_ROOT; };
 		507FA6EFF17810ED320DE318 /* ProviderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderRegistryTests.swift; sourceTree = "<group>"; };
 		530B806F812350D8094AA0EC /* DashboardWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardWindow.swift; sourceTree = "<group>"; };
 		551CF929C655CBA53D7A432E /* frame_06.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = frame_06.png; sourceTree = "<group>"; };
@@ -175,15 +167,14 @@
 		5B278895C8F3233433F88309 /* TokenFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenFormatter.swift; sourceTree = "<group>"; };
 		5B4DCE60EE179E52F278B447 /* TokenUsageChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenUsageChart.swift; sourceTree = "<group>"; };
 		5D82D563F2B758C1208E987E /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
-		607D77AED90E38601083C087 /* run_06.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = run_06.png; sourceTree = "<group>"; };
 		617E28351290F97E1B3742F0 /* DashboardConfigStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardConfigStore.swift; sourceTree = "<group>"; };
 		61DDA70E53ACA059A333371E /* frame_04.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = frame_04.png; sourceTree = "<group>"; };
 		6576E137DF2FCFE73BE66102 /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
-		660A4FE97F12851611B35159 /* run_03.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = run_03.png; sourceTree = "<group>"; };
 		689790D76D5DEE3F14EB819D /* AppIcon_1024.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AppIcon_1024.png; sourceTree = "<group>"; };
 		6B17BA2BAF5855E537D1C1D0 /* AnimationTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationTheme.swift; sourceTree = "<group>"; };
 		6EB3ECA48F693919010308AC /* ChartPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartPanel.swift; sourceTree = "<group>"; };
 		6FA1754431AB65F03A7CBB13 /* PanelResizeHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelResizeHandle.swift; sourceTree = "<group>"; };
+		7368908C5687B4CB8281CE2C /* ModelPricing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPricing.swift; sourceTree = "<group>"; };
 		74A27A6A118A446539806BB7 /* TokiReportModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokiReportModels.swift; sourceTree = "<group>"; };
 		750080E9CA86B9101502A6B7 /* TokiReportClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokiReportClientTests.swift; sourceTree = "<group>"; };
 		755C88AB0D9EE0E7EDC3CDAE /* TokiEventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokiEventStreamTests.swift; sourceTree = "<group>"; };
@@ -196,15 +187,11 @@
 		8B4247163632AC4A7FF3582B /* TokiEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokiEvent.swift; sourceTree = "<group>"; };
 		8E22EEB558886ED30F51E583 /* PlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistView.swift; sourceTree = "<group>"; };
 		939B1E3BEBAB1C0FF5C3ED6B /* AlertListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertListView.swift; sourceTree = "<group>"; };
-		93DBD83CDA2E2CEAB600F3BB /* run_02.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = run_02.png; sourceTree = "<group>"; };
 		955951A7FF5652C64A116C70 /* ClaudeUsageMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeUsageMonitor.swift; sourceTree = "<group>"; };
 		9953C511BFF1317C46D027D6 /* PlaylistManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistManager.swift; sourceTree = "<group>"; };
-		9C34A2D8996268241E877C53 /* theme.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = theme.json; sourceTree = "<group>"; };
 		9CA03537C2F0CAF1D37B5252 /* TablePanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TablePanelView.swift; sourceTree = "<group>"; };
-		9F47734BE06CE332F023528D /* run_00.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = run_00.png; sourceTree = "<group>"; };
 		A0132BCEBA0D76465E41F08A /* frame_00_thin.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = frame_00_thin.png; sourceTree = "<group>"; };
 		A285CEF82274757C8A327142 /* TimeSeriesModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSeriesModels.swift; sourceTree = "<group>"; };
-		A3009FD2313EE41259DC8037 /* run_04.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = run_04.png; sourceTree = "<group>"; };
 		A56E6C47FB0555F57056DA13 /* frame_02.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = frame_02.png; sourceTree = "<group>"; };
 		A5B5567C5B301D96AB614B4E /* PanelContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelContainerView.swift; sourceTree = "<group>"; };
 		A6C1751117D1E380839B3A0E /* StatusBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarController.swift; sourceTree = "<group>"; };
@@ -222,7 +209,6 @@
 		C4C36A205DFC4F7DA9CD54A9 /* VersionCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionCompatibility.swift; sourceTree = "<group>"; };
 		C89A62671E6B8235B289897B /* frame_05.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = frame_05.png; sourceTree = "<group>"; };
 		CA89702E4E5B1108842AA475 /* ProviderRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderRegistry.swift; sourceTree = "<group>"; };
-		D4E5F6071809A1B2C3D4E5F6 /* ModelPricing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPricing.swift; sourceTree = "<group>"; };
 		CBE42DEDC857AB657D449C5E /* ClaudeAuthReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeAuthReader.swift; sourceTree = "<group>"; };
 		D0A80F24970E2F377FB13231 /* DashboardEditOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardEditOverlay.swift; sourceTree = "<group>"; };
 		D1837716A9BFD555E0A36B8A /* SyncSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncSettingsView.swift; sourceTree = "<group>"; };
@@ -310,27 +296,12 @@
 		2B53C31A8AFD444EB1D97241 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				4C9D9972B2FA620BD19C947D /* Animations */,
 				689790D76D5DEE3F14EB819D /* AppIcon_1024.png */,
 				B572F782B925386C0B035893 /* Assets.xcassets */,
-				5E22B5CFE0DAEB06369BFF3E /* Animations */,
 				BD2650D4EB7E982A11AB3D8C /* CharacterFrames */,
 			);
 			path = Resources;
-			sourceTree = "<group>";
-		};
-		3BF8772954E03AA428AB4516 /* rabbit */ = {
-			isa = PBXGroup;
-			children = (
-				9F47734BE06CE332F023528D /* run_00.png */,
-				4921C5A600FE4FF1E20BB12C /* run_01.png */,
-				93DBD83CDA2E2CEAB600F3BB /* run_02.png */,
-				660A4FE97F12851611B35159 /* run_03.png */,
-				A3009FD2313EE41259DC8037 /* run_04.png */,
-				427ED7AB9807D9DD887EBD92 /* run_05.png */,
-				607D77AED90E38601083C087 /* run_06.png */,
-				9C34A2D8996268241E877C53 /* theme.json */,
-			);
-			path = rabbit;
 			sourceTree = "<group>";
 		};
 		3CC06E198D87E843450910CE /* MenuBar */ = {
@@ -386,14 +357,6 @@
 				2A3062764644CB53A2DA4066 /* Panels */,
 			);
 			path = Dashboard;
-			sourceTree = "<group>";
-		};
-		5E22B5CFE0DAEB06369BFF3E /* Animations */ = {
-			isa = PBXGroup;
-			children = (
-				3BF8772954E03AA428AB4516 /* rabbit */,
-			);
-			path = Animations;
 			sourceTree = "<group>";
 		};
 		6F53294CD1B846096FA8B725 /* OAuth */ = {
@@ -524,9 +487,9 @@
 				617E28351290F97E1B3742F0 /* DashboardConfigStore.swift */,
 				DD104D8D23446C055623FC7D /* DashboardVersionStore.swift */,
 				DA62A18D444F7F8A7D39F9B6 /* Localization.swift */,
+				7368908C5687B4CB8281CE2C /* ModelPricing.swift */,
 				F61E686B7BA4F794ABE3C325 /* PanelDataExtractor.swift */,
 				9953C511BFF1317C46D027D6 /* PlaylistManager.swift */,
-				D4E5F6071809A1B2C3D4E5F6 /* ModelPricing.swift */,
 				CA89702E4E5B1108842AA475 /* ProviderRegistry.swift */,
 				37F55200D88B2D7260541C5D /* ProviderSummary.swift */,
 				4BDA0DC9C4300E5F7B2E3F2A /* SyncManager.swift */,
@@ -617,6 +580,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3574E94BBA0BB4EA83DB6F40 /* Animations in Resources */,
 				F4E2F3776A2D4DB6AEF2D86C /* AppIcon_1024.png in Resources */,
 				C4E3FFDC972A212EEC371464 /* Assets.xcassets in Resources */,
 				0C102E5047654E452890DC1C /* frame_00.png in Resources */,
@@ -627,14 +591,6 @@
 				9449B23FF1F7AD404910F919 /* frame_04.png in Resources */,
 				4DF008865414431174E7637E /* frame_05.png in Resources */,
 				2B4230ABE31D423999570F70 /* frame_06.png in Resources */,
-				D1CEF03ED06D451B4D02A7D9 /* run_00.png in Resources */,
-				39DF561B00E6866F5F760219 /* run_01.png in Resources */,
-				3D7278E964B217624992A688 /* run_02.png in Resources */,
-				E0AAF320A888951229785FE1 /* run_03.png in Resources */,
-				B1BEE5085C8777D9EF876A04 /* run_04.png in Resources */,
-				3332CEA99B4EBD15C418D910 /* run_05.png in Resources */,
-				4FBBB2CEEBB26DDD1E82279C /* run_06.png in Resources */,
-				6BEC823E63A5B721FA4F154E /* theme.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -687,6 +643,7 @@
 				F44113AFD5BFD92DF64B478C /* Localization.swift in Sources */,
 				3B53DEBD38340CE172E5019E /* MenuBarSettingsPane.swift in Sources */,
 				0AD59AAAF77D174E97E09FF8 /* MenuContentView.swift in Sources */,
+				D9AED0BD0367047F1034D688 /* ModelPricing.swift in Sources */,
 				555FD7C25C250BCAB0806025 /* NotificationsSettingsPane.swift in Sources */,
 				C86ECFD5EE31C3BE52418E7D /* OAuthModels.swift in Sources */,
 				A44EE6876D0A1DB2E6036DFD /* PanelContainerView.swift in Sources */,
@@ -698,7 +655,6 @@
 				417DA2C685E33E4F4E375DE4 /* PlaylistManager.swift in Sources */,
 				F517514F5BE935557A7EA1AA /* PlaylistView.swift in Sources */,
 				27611784EBE8056DB13584F9 /* ProviderColor.swift in Sources */,
-				A1B2C3D4E5F60718091A2B3C /* ModelPricing.swift in Sources */,
 				2C5565559581A5B645B3349C /* ProviderRegistry.swift in Sources */,
 				46DF834236EAC2C92B2F93AE /* ProviderSummary.swift in Sources */,
 				1ABD9FFEA542EBFB957B76CD /* ProvidersSettingsPane.swift in Sources */,

--- a/TokiMonitor/Domain/AlertManager.swift
+++ b/TokiMonitor/Domain/AlertManager.swift
@@ -7,7 +7,7 @@ final class AlertManager {
     private static let storeKey = "dashboardAlertRules"
     private var evaluationTimer: Timer?
 
-    func startEvaluation(dataProvider: @escaping () -> Double?) {
+    func startEvaluation(dataProvider: @escaping @MainActor () -> Double?) {
         evaluationTimer?.invalidate()
         evaluationTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
@@ -61,7 +61,7 @@ final class AlertManager {
 
     // MARK: - Evaluation
 
-    private func evaluateAll(dataProvider: @escaping () -> Double?) {
+    private func evaluateAll(dataProvider: @escaping @MainActor () -> Double?) {
         var all = loadAll()
         for i in all.indices where all[i].enabled {
             let value = dataProvider()

--- a/TokiMonitor/Domain/AppSettings.swift
+++ b/TokiMonitor/Domain/AppSettings.swift
@@ -706,7 +706,8 @@ enum UsageAlertHelpers {
     struct BucketCheck {
         let bucket: UsageAlertBucket
         let utilization: Double?
-        let resetId: String
+        /// nil = reset window unknown; threshold check is skipped to avoid deduplication confusion.
+        let resetId: String?
     }
 
     /// threshold check 수행 후 필요 시 알림 발송.
@@ -717,14 +718,15 @@ enum UsageAlertHelpers {
         settings: AppSettings
     ) {
         for item in items {
-            guard let utilization = item.utilization else { continue }
+            guard let utilization = item.utilization,
+                  let resetId = item.resetId else { continue }
 
             if utilization >= 90,
                settings.usageAlert90Enabled,
                settings.isUsageAlertBucketEnabled(.percent90, bucket: item.bucket) {
                 let store = UsageAlertStateStore.shared
-                if !store.hasNotified(threshold: .percent90, bucket: item.bucket, resetId: item.resetId) {
-                    store.markNotified(threshold: .percent90, bucket: item.bucket, resetId: item.resetId)
+                if !store.hasNotified(threshold: .percent90, bucket: item.bucket, resetId: resetId) {
+                    store.markNotified(threshold: .percent90, bucket: item.bucket, resetId: resetId)
                     sendNotification(providerTitle: providerTitle, bucketLabel: item.bucket.displayName, threshold: 90)
                 }
                 continue
@@ -734,8 +736,8 @@ enum UsageAlertHelpers {
                settings.usageAlert75Enabled,
                settings.isUsageAlertBucketEnabled(.percent75, bucket: item.bucket) {
                 let store = UsageAlertStateStore.shared
-                if !store.hasNotified(threshold: .percent75, bucket: item.bucket, resetId: item.resetId) {
-                    store.markNotified(threshold: .percent75, bucket: item.bucket, resetId: item.resetId)
+                if !store.hasNotified(threshold: .percent75, bucket: item.bucket, resetId: resetId) {
+                    store.markNotified(threshold: .percent75, bucket: item.bucket, resetId: resetId)
                     sendNotification(providerTitle: providerTitle, bucketLabel: item.bucket.displayName, threshold: 75)
                 }
             }

--- a/TokiMonitor/Domain/ClaudeUsageMonitor.swift
+++ b/TokiMonitor/Domain/ClaudeUsageMonitor.swift
@@ -73,10 +73,12 @@ final class ClaudeUsageMonitor {
     private(set) var lastError: String?
     private(set) var isAvailable: Bool = false
     var isPolling: Bool { pollingTask != nil }
+    var isInBackoff: Bool { consecutiveFailures > 0 }
 
     private let aggregator: TokenAggregator
     private let settings: AppSettings
     private var pollingTask: Task<Void, Never>?
+    private var sleepTask: Task<Void, Never>?
     private var consecutiveFailures = 0
 
     init(aggregator: TokenAggregator, settings: AppSettings) {
@@ -94,14 +96,26 @@ final class ClaudeUsageMonitor {
                 guard let self else { return }
                 await self.pollOnce()
                 let interval = self.computeInterval()
-                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                self.sleepTask = Task {
+                    try? await Task.sleep(for: .seconds(interval))
+                }
+                await self.sleepTask?.value
+                self.sleepTask = nil
             }
         }
     }
 
     func stopPolling() {
+        sleepTask?.cancel()
+        sleepTask = nil
         pollingTask?.cancel()
         pollingTask = nil
+    }
+
+    /// 현재 sleep 중이면 즉시 중단하고 다음 poll을 앞당깁니다.
+    func wakeForImmediatePoll() {
+        guard pollingTask != nil else { return }
+        sleepTask?.cancel()
     }
 
     // MARK: - Polling
@@ -144,12 +158,15 @@ final class ClaudeUsageMonitor {
 
     private func computeInterval() -> TimeInterval {
         if !isAvailable { return 60 }
+        // Backoff capped at 60s: recovers within 1 minute after transient server errors
         if consecutiveFailures > 0 {
-            return min(15 * pow(2, Double(consecutiveFailures - 1)), 300)
+            return min(15 * pow(2, Double(consecutiveFailures - 1)), 60)
         }
         if currentUsage == nil { return 15 }
-        if let usage = currentUsage, usage.maxUtilization > 75 { return 120 }
-        if aggregator.tokensPerMinute > 0 { return 180 }
+        // High utilization or heavy token flow → poll aggressively
+        if let usage = currentUsage, usage.maxUtilization > 75 { return 60 }
+        if aggregator.tokensPerMinute > 5000 { return 60 }
+        if aggregator.tokensPerMinute > 0 { return 120 }
         return 300
     }
 
@@ -157,9 +174,9 @@ final class ClaudeUsageMonitor {
 
     private func checkThresholds(_ usage: ClaudeUsageResponse) {
         UsageAlertHelpers.checkThresholds([
-            .init(bucket: .claudeFiveHour,      utilization: usage.fiveHour?.utilization,      resetId: usage.fiveHour?.resetsAt      ?? "unknown"),
-            .init(bucket: .claudeSevenDay,      utilization: usage.sevenDay?.utilization,      resetId: usage.sevenDay?.resetsAt      ?? "unknown"),
-            .init(bucket: .claudeSevenDaySonnet, utilization: usage.sevenDaySonnet?.utilization, resetId: usage.sevenDaySonnet?.resetsAt ?? "unknown"),
+            .init(bucket: .claudeFiveHour,       utilization: usage.fiveHour?.utilization,       resetId: usage.fiveHour?.resetsAt),
+            .init(bucket: .claudeSevenDay,       utilization: usage.sevenDay?.utilization,       resetId: usage.sevenDay?.resetsAt),
+            .init(bucket: .claudeSevenDaySonnet, utilization: usage.sevenDaySonnet?.utilization, resetId: usage.sevenDaySonnet?.resetsAt),
         ], providerTitle: L.panel.claudeUsage, settings: settings)
     }
 }

--- a/TokiMonitor/Domain/CodexUsageMonitor.swift
+++ b/TokiMonitor/Domain/CodexUsageMonitor.swift
@@ -93,8 +93,12 @@ final class CodexUsageMonitor {
     private(set) var lastError: String?
     private(set) var isAvailable: Bool = false
     var isPolling: Bool { pollingTask != nil }
+    /// true = 일시적 서버 오류로 backoff 중. 인증 오류(401/403)는 포함하지 않음 — 재시도해도 의미 없음.
+    var isInTransientBackoff: Bool { consecutiveFailures > 0 && !isAuthError }
+    private(set) var isAuthError: Bool = false
 
     private var pollingTask: Task<Void, Never>?
+    private var sleepTask: Task<Void, Never>?
     private let aggregator: TokenAggregator
     private let settings: AppSettings
     private var consecutiveFailures = 0
@@ -121,15 +125,27 @@ final class CodexUsageMonitor {
                 guard let self else { return }
                 await self.pollOnce()
                 let interval = self.computeInterval()
-                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                self.sleepTask = Task {
+                    try? await Task.sleep(for: .seconds(interval))
+                }
+                await self.sleepTask?.value
+                self.sleepTask = nil
             }
         }
     }
 
     func stopPolling() {
+        sleepTask?.cancel()
+        sleepTask = nil
         pollingTask?.cancel()
         pollingTask = nil
         stopFileWatcher()
+    }
+
+    /// 현재 sleep 중이면 즉시 중단하고 다음 poll을 앞당깁니다.
+    func wakeForImmediatePoll() {
+        guard pollingTask != nil else { return }
+        sleepTask?.cancel()
     }
 
     // MARK: - Polling
@@ -149,11 +165,13 @@ final class CodexUsageMonitor {
             currentUsage = usage
             lastError = nil
             consecutiveFailures = 0
+            isAuthError = false
             settings.codexHasSecondaryWindow = (usage.rateLimit.secondaryWindow != nil)
             checkThresholds(usage)
         } catch let error as CodexAuthError {
             switch error {
             case .fetchFailed(401), .fetchFailed(403):
+                isAuthError = true
                 consecutiveFailures += 1
                 if consecutiveFailures >= 3 {
                     lastError = L.tr("Codex 재로그인 필요", "Codex re-login required")
@@ -183,8 +201,8 @@ final class CodexUsageMonitor {
 
     private func checkThresholds(_ usage: CodexUsageResponse) {
         UsageAlertHelpers.checkThresholds([
-            .init(bucket: .codexPrimary,   utilization: usage.rateLimit.primaryWindow.map   { Double($0.usedPercent) }, resetId: usage.rateLimit.primaryWindow.map   { String($0.resetAt) } ?? "unknown"),
-            .init(bucket: .codexSecondary, utilization: usage.rateLimit.secondaryWindow.map { Double($0.usedPercent) }, resetId: usage.rateLimit.secondaryWindow.map { String($0.resetAt) } ?? "unknown"),
+            .init(bucket: .codexPrimary,   utilization: usage.rateLimit.primaryWindow.map   { Double($0.usedPercent) }, resetId: usage.rateLimit.primaryWindow.map   { String($0.resetAt) }),
+            .init(bucket: .codexSecondary, utilization: usage.rateLimit.secondaryWindow.map { Double($0.usedPercent) }, resetId: usage.rateLimit.secondaryWindow.map { String($0.resetAt) }),
         ], providerTitle: L.tr("Codex 사용량", "Codex Usage"), settings: settings)
     }
 
@@ -213,6 +231,7 @@ final class CodexUsageMonitor {
                 guard let self else { return }
                 // Token was refreshed — reset failures and retry immediately
                 self.consecutiveFailures = 0
+                self.isAuthError = false
                 self.lastError = nil
 
                 // If polling was in a long backoff, restart it
@@ -224,7 +243,9 @@ final class CodexUsageMonitor {
                     }
                 }
 
-                await self.pollOnce()
+                // Wake the polling loop instead of calling pollOnce() directly
+                // to avoid a double-poll race with the main polling task.
+                self.wakeForImmediatePoll()
             }
         }
 
@@ -240,18 +261,17 @@ final class CodexUsageMonitor {
     // MARK: - Adaptive Interval
 
     private func computeInterval() -> TimeInterval {
+        // Backoff capped at 60s: recovers within 1 minute after transient errors/auth expiry
         if consecutiveFailures > 0 {
-            // Exponential backoff: 30s, 60s, 120s, max 300s
-            return min(30 * pow(2, Double(consecutiveFailures - 1)), 300)
+            return min(30 * pow(2, Double(consecutiveFailures - 1)), 60)
         }
+        if currentUsage == nil { return 15 }
+        // High utilization or heavy token flow → poll aggressively
         if let usage = currentUsage,
            let primary = usage.rateLimit.primaryWindow,
-           primary.usedPercent > 75 {
-            return 120
-        }
-        if aggregator.tokensPerMinute > 0 {
-            return 180
-        }
+           primary.usedPercent > 75 { return 60 }
+        if aggregator.tokensPerMinute > 5000 { return 60 }
+        if aggregator.tokensPerMinute > 0 { return 120 }
         return 300
     }
 }

--- a/TokiMonitor/Domain/ConnectionManager.swift
+++ b/TokiMonitor/Domain/ConnectionManager.swift
@@ -158,6 +158,7 @@ final class ConnectionManager {
     }
 
     /// Run a toki CLI command. Returns true if exit code 0.
+    /// Enforces a 15-second timeout to prevent indefinite hang on daemon start/stop.
     private func runToki(args: [String]) async -> Bool {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .utility).async {
@@ -167,12 +168,29 @@ final class ConnectionManager {
                 process.standardOutput = FileHandle.nullDevice
                 process.standardError = FileHandle.nullDevice
 
+                let lock = NSLock()
+                var didResume = false
+                func resumeOnce(_ value: Bool) {
+                    lock.lock(); defer { lock.unlock() }
+                    guard !didResume else { return }
+                    didResume = true
+                    continuation.resume(returning: value)
+                }
+
                 do {
                     try process.run()
+
+                    let timeoutItem = DispatchWorkItem {
+                        if process.isRunning { process.terminate() }
+                        resumeOnce(false)
+                    }
+                    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 15, execute: timeoutItem)
+
                     process.waitUntilExit()
-                    continuation.resume(returning: process.terminationStatus == 0)
+                    timeoutItem.cancel()
+                    resumeOnce(process.terminationStatus == 0)
                 } catch {
-                    continuation.resume(returning: false)
+                    resumeOnce(false)
                 }
             }
         }

--- a/TokiMonitor/Domain/PlaylistManager.swift
+++ b/TokiMonitor/Domain/PlaylistManager.swift
@@ -39,7 +39,7 @@ final class PlaylistManager {
 
     // MARK: - Playback
 
-    func play(playlistID: UUID, onSwitch: @escaping (String) -> Void) {
+    func play(playlistID: UUID, onSwitch: @escaping @MainActor (String) -> Void) {
         guard let playlist = playlists.first(where: { $0.id == playlistID }),
               !playlist.dashboardUIDs.isEmpty else { return }
 
@@ -75,7 +75,7 @@ final class PlaylistManager {
         currentIndex = 0
     }
 
-    func next(onSwitch: @escaping (String) -> Void) {
+    func next(onSwitch: @escaping @MainActor (String) -> Void) {
         guard let playlistID = currentPlaylistID,
               let playlist = playlists.first(where: { $0.id == playlistID })
         else { return }
@@ -83,7 +83,7 @@ final class PlaylistManager {
         onSwitch(playlist.dashboardUIDs[currentIndex])
     }
 
-    func previous(onSwitch: @escaping (String) -> Void) {
+    func previous(onSwitch: @escaping @MainActor (String) -> Void) {
         guard let playlistID = currentPlaylistID,
               let playlist = playlists.first(where: { $0.id == playlistID })
         else { return }

--- a/TokiMonitor/Domain/VersionCompatibility.swift
+++ b/TokiMonitor/Domain/VersionCompatibility.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// Must be bumped whenever toki introduces breaking protocol changes.
 let requiredTokiMajorVersion = 2
 
-/// Checks toki CLI major version and shows a non-dismissible modal if outdated.
+/// Checks toki CLI major version and shows an update-required modal if outdated.
 @MainActor
 final class VersionCompatibilityChecker {
 
@@ -27,7 +27,7 @@ final class VersionCompatibilityChecker {
     }
 
     /// Check version on launch. If toki is installed but major version is too old,
-    /// shows a non-dismissible update-required modal and disables query features.
+    /// shows an update-required modal and disables query features.
     /// If toki is not installed, does nothing (toki-monitor can still work via daemon).
     func checkOnLaunch() {
         Task {
@@ -42,7 +42,7 @@ final class VersionCompatibilityChecker {
 
     private var updateWindow: NSWindow?
 
-    /// Run brew upgrade toki, wait for completion, re-check version, dismiss modal if OK.
+    /// Open Terminal with brew upgrade toki.
     private func runUpdate() {
         let scriptPath = NSTemporaryDirectory() + "toki-version-update.command"
         let script = """
@@ -54,32 +54,37 @@ final class VersionCompatibilityChecker {
         try? script.write(toFile: scriptPath, atomically: true, encoding: .utf8)
         chmod(scriptPath, 0o755)
         NSWorkspace.shared.open(URL(fileURLWithPath: scriptPath))
+    }
 
-        // Poll until the version is updated (check every 3 seconds, up to 2 minutes)
-        Task {
-            for _ in 0..<40 {
-                try? await Task.sleep(nanoseconds: 3_000_000_000)
-                if let major = await installedTokiMajorVersion(), major >= requiredTokiMajorVersion {
-                    updateWindow?.close()
-                    updateWindow = nil
-                    return
-                }
-            }
+    /// Re-check version and close modal if now up to date. Returns true if OK.
+    func recheckVersion() async -> Bool {
+        guard let major = await installedTokiMajorVersion() else { return false }
+        if major >= requiredTokiMajorVersion {
+            updateWindow?.close()
+            updateWindow = nil
+            return true
         }
+        return false
     }
 
     private func showUpdateRequiredModal(installedMajor: Int) {
-        var view = TokiUpdateRequiredView(
+        let view = TokiUpdateRequiredView(
             installedVersion: "v\(installedMajor).x",
-            requiredVersion: "v\(requiredTokiMajorVersion)"
+            requiredVersion: "v\(requiredTokiMajorVersion)",
+            onUpdate: { [weak self] in self?.runUpdate() },
+            onRecheck: { [weak self] in
+                guard let self else { return }
+                Task { await self.recheckVersion() }
+            },
+            onDismiss: { [weak self] in
+                self?.updateWindow?.close()
+                self?.updateWindow = nil
+            }
         )
-        view.onUpdate = { [weak self] in
-            self?.runUpdate()
-        }
         let hostingController = NSHostingController(rootView: view)
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 440, height: 240),
-            styleMask: [.titled],
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 260),
+            styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
         )
@@ -87,15 +92,12 @@ final class VersionCompatibilityChecker {
         window.title = L.tr("toki 업데이트 필요", "toki Update Required")
         window.isReleasedWhenClosed = false
         window.level = .modalPanel
-        // Non-dismissible: no close button, ESC does nothing
-        window.standardWindowButton(.closeButton)?.isEnabled = false
-        window.standardWindowButton(.closeButton)?.isHidden = true
 
         if let screen = NSScreen.main {
             let sf = screen.frame
             let size = hostingController.view.fittingSize
             let w = max(size.width, 440)
-            let h = max(size.height, 240)
+            let h = max(size.height, 260)
             let x = sf.origin.x + (sf.width - w) / 2
             let y = sf.origin.y + (sf.height - h) / 2
             window.setFrame(NSRect(x: x, y: y, width: w, height: h), display: true)
@@ -112,6 +114,13 @@ final class VersionCompatibilityChecker {
 private struct TokiUpdateRequiredView: View {
     let installedVersion: String
     let requiredVersion: String
+    let onUpdate: () -> Void
+    let onRecheck: () -> Void
+    let onDismiss: () -> Void
+
+    @State private var didClickUpdate = false
+    @State private var isRechecking = false
+    @State private var recheckFailed = false
 
     var body: some View {
         VStack(spacing: 20) {
@@ -132,14 +141,51 @@ private struct TokiUpdateRequiredView: View {
                 .multilineTextAlignment(.center)
             }
 
-            Button(L.tr("지금 업데이트", "Update Now")) {
-                onUpdate()
+            if recheckFailed {
+                Text(L.tr("아직 업데이트가 완료되지 않았습니다.", "Update not yet complete."))
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
             }
-            .keyboardShortcut(.defaultAction)
+
+            if !didClickUpdate {
+                HStack(spacing: 12) {
+                    Button(L.tr("나중에", "Later")) {
+                        onDismiss()
+                    }
+                    Button(L.tr("지금 업데이트", "Update Now")) {
+                        onUpdate()
+                        didClickUpdate = true
+                        recheckFailed = false
+                    }
+                    .keyboardShortcut(.defaultAction)
+                }
+            } else {
+                HStack(spacing: 12) {
+                    Button(L.tr("나중에", "Later")) {
+                        onDismiss()
+                    }
+                    Button(L.tr("업데이트 완료 → 재확인", "Done Updating → Re-check")) {
+                        isRechecking = true
+                        recheckFailed = false
+                        onRecheck()
+                        // Give it a moment then reset rechecking state if not closed
+                        Task {
+                            try? await Task.sleep(for: .seconds(3))
+                            isRechecking = false
+                            recheckFailed = true
+                        }
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(isRechecking)
+                    .overlay {
+                        if isRechecking {
+                            ProgressView().scaleEffect(0.6)
+                        }
+                    }
+                }
+            }
         }
         .padding(24)
         .frame(width: 440)
     }
-
-    var onUpdate: () -> Void = {}
 }

--- a/TokiMonitor/Info.plist
+++ b/TokiMonitor/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0</string>
+	<string>0.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSUIElement</key>
 	<true/>
 </dict>

--- a/TokiMonitor/Info.plist
+++ b/TokiMonitor/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>2</string>
 	<key>LSUIElement</key>

--- a/TokiMonitor/Presentation/MenuBar/CharacterAnimationView.swift
+++ b/TokiMonitor/Presentation/MenuBar/CharacterAnimationView.swift
@@ -132,54 +132,19 @@ final class CharacterAnimationRenderer {
         // Default to "rabbit", fallback to first available
         theme = themes.first(where: { $0.config.id == "rabbit" }) ?? themes.first
 
-        // Fallback: load from legacy CharacterFrames location
+        // Ultimate fallback: placeholder circles
         if theme == nil {
-            loadLegacyFrames()
-        }
-    }
-
-    private func loadLegacyFrames() {
-        let bundle = Bundle.main
-        let frameSize = NSSize(width: 24, height: 18)
-        let canvasSize = NSSize(width: 28, height: 18)
-
-        var runFrames: [NSImage] = []
-        for i in 0..<7 {
-            let name = String(format: "frame_%02d", i)
-            guard let url = bundle.url(forResource: name, withExtension: "png"),
-                  let src = NSImage(contentsOf: url) else { continue }
-            src.size = frameSize
-            let canvas = NSImage(size: canvasSize, flipped: false) { _ in
-                src.draw(in: NSRect(origin: .zero, size: frameSize))
-                return true
-            }
-            canvas.isTemplate = true
-            runFrames.append(canvas)
-        }
-
-        guard !runFrames.isEmpty else {
-            // Ultimate fallback: placeholder circles
             let placeholderConfig = AnimationThemeConfig(
                 id: "placeholder", name: "Placeholder",
                 frameSize: [18, 18], canvasSize: [18, 18],
                 sleep: .init(mode: "overlay")
             )
-            let placeholders = generatePlaceholderFrames()
             theme = AnimationTheme(
                 config: placeholderConfig,
-                runFrames: placeholders,
+                runFrames: generatePlaceholderFrames(),
                 sleepFrames: []
             )
-            return
         }
-
-        let config = AnimationThemeConfig(
-            id: "rabbit", name: "Rabbit",
-            frameSize: [24, 18], canvasSize: [28, 18],
-            sleep: .init(mode: "overlay", textOffset: [-7, -1], fontSize: 5, interval: 0.8)
-        )
-        let sleepFrames = AnimationTheme.generateOverlaySleepFrames(base: runFrames[0], config: config)
-        theme = AnimationTheme(config: config, runFrames: runFrames, sleepFrames: sleepFrames)
     }
 
     private weak var hpBarView: HPBarView?

--- a/TokiMonitor/Presentation/MenuBar/MenuContentView.swift
+++ b/TokiMonitor/Presentation/MenuBar/MenuContentView.swift
@@ -267,28 +267,7 @@ struct MenuContentView: View {
     }
 
     private func usageBar(_ label: String, _ b: UsageBucket) -> some View {
-        VStack(alignment: .leading, spacing: DS.xs) {
-            HStack {
-                Text(label)
-                    .font(.system(size: DS.fontCaption))
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Text("\(Int(b.utilization))%")
-                    .font(.system(size: DS.fontCaption, weight: .semibold, design: .monospaced))
-                Text("· \(b.resetCountdown)")
-                    .font(.system(size: DS.fontTiny))
-                    .foregroundStyle(.tertiary)
-            }
-            GeometryReader { g in
-                ZStack(alignment: .leading) {
-                    RoundedRectangle(cornerRadius: 2, style: .continuous).fill(.quaternary)
-                    RoundedRectangle(cornerRadius: 2, style: .continuous)
-                        .fill(b.utilization >= 90 ? .red : b.utilization >= 75 ? .orange : b.utilization >= 50 ? .yellow : .green)
-                        .frame(width: max(g.size.width * min(b.utilization / 100, 1), 3))
-                }
-            }
-            .frame(height: 4)
-        }
+        usageProgressBar(label: label, percent: b.utilization, countdown: b.resetCountdown)
     }
 
     // MARK: - Codex Usage Widget
@@ -334,13 +313,17 @@ struct MenuContentView: View {
     }
 
     private func codexUsageBar(_ label: String, percent: Int, countdown: String) -> some View {
+        usageProgressBar(label: label, percent: Double(percent), countdown: countdown)
+    }
+
+    private func usageProgressBar(label: String, percent: Double, countdown: String) -> some View {
         VStack(alignment: .leading, spacing: DS.xs) {
             HStack {
                 Text(label)
                     .font(.system(size: DS.fontCaption))
                     .foregroundStyle(.secondary)
                 Spacer()
-                Text("\(percent)%")
+                Text("\(Int(percent))%")
                     .font(.system(size: DS.fontCaption, weight: .semibold, design: .monospaced))
                 Text("· \(countdown)")
                     .font(.system(size: DS.fontTiny))
@@ -351,7 +334,7 @@ struct MenuContentView: View {
                     RoundedRectangle(cornerRadius: 2, style: .continuous).fill(.quaternary)
                     RoundedRectangle(cornerRadius: 2, style: .continuous)
                         .fill(percent >= 90 ? .red : percent >= 75 ? .orange : percent >= 50 ? .yellow : .green)
-                        .frame(width: max(g.size.width * min(Double(percent) / 100, 1), 3))
+                        .frame(width: max(g.size.width * min(percent / 100, 1), 3))
                 }
             }
             .frame(height: 4)

--- a/TokiMonitor/Presentation/MenuBar/StatusBarController.swift
+++ b/TokiMonitor/Presentation/MenuBar/StatusBarController.swift
@@ -95,6 +95,7 @@ final class StatusBarController {
         // Observe
         observeTokenRate()
         observeSettings()
+        observeTokenActivity()
     }
 
     // MARK: - First Launch & Daemon
@@ -355,10 +356,16 @@ final class StatusBarController {
 
         // Position below the clicked status item
         if let button = unit.statusItem.button,
-           let window = button.window {
-            let buttonFrame = window.convertToScreen(button.convert(button.bounds, to: nil))
+           let buttonWindow = button.window {
+            // Convert button bounds to global screen coordinates for accurate positioning.
+            // Use button.window.screen to find the actual screen the status item is on,
+            // rather than NSScreen.main which points to the key-window screen (wrong on multi-display).
+            let buttonFrame = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
+            let screen = buttonWindow.screen
+                ?? NSScreen.screens.first(where: { $0.frame.contains(buttonFrame.origin) })
+                ?? NSScreen.main
+            let screenFrame = screen?.visibleFrame ?? .zero
             let contentSize = hostingView.fittingSize
-            let screenFrame = NSScreen.main?.visibleFrame ?? .zero
 
             // Set content size — panel auto-calculates frame including titlebar
             panel.setContentSize(contentSize)
@@ -484,6 +491,28 @@ final class StatusBarController {
     }
 
     // MARK: - Observation
+
+    /// token rate가 0→nonzero로 전환될 때 usage monitor sleep을 즉시 중단하고 poll 앞당김.
+    private var wasTokenActive = false
+
+    private func observeTokenActivity() {
+        withObservationTracking {
+            _ = aggregator.tokensPerMinute
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let isActive = self.aggregator.tokensPerMinute > 0
+                if isActive && !self.wasTokenActive {
+                    // 토큰이 흐르기 시작했다 = 연결이 살아있다.
+                    // 에러 backoff 중인 monitor만 즉시 재시도.
+                    if self.usageMonitor.isInBackoff { self.usageMonitor.wakeForImmediatePoll() }
+                    if self.codexUsageMonitor.isInTransientBackoff { self.codexUsageMonitor.wakeForImmediatePoll() }
+                }
+                self.wasTokenActive = isActive
+                self.observeTokenActivity()
+            }
+        }
+    }
 
     private func observeTokenRate() {
         withObservationTracking {

--- a/project.yml
+++ b/project.yml
@@ -22,8 +22,9 @@ targets:
         excludes:
           - "**/*Tests*"
           - "**/Tests/**"
-    resources:
-      - path: TokiMonitor/Resources/CharacterFrames
+          - "Resources/Animations/**"
+      - path: TokiMonitor/Resources/Animations
+        type: folder
         buildPhase: resources
     settings:
       base:


### PR DESCRIPTION
## Summary

- **멀티 모니터 패널 위치 버그 수정** (issue #5): 듀얼 모니터 상단/하단 배치 시 패널이 엉뚱한 화면에 뜨는 문제 — `NSScreen.main` 대신 `buttonWindow.screen` 사용
- **캐릭터 애니메이션 빈 Picker 수정**: XcodeGen `type: folder` 설정으로 Animations 번들 경로 정상화
- **업데이트 모달 닫기 불가 수정** (issue #4): 폴링 루프 제거, 닫기 버튼 및 수동 재확인 버튼 추가
- **적응형 폴링**: 에러 backoff 중 토큰 흐름 감지 시 즉시 재시도, Codex 인증 오류와 일시적 오류 구분, fileWatcher 이중 폴링 경쟁 제거
- **기타 버그 수정**: resetId nil 처리, runToki 15초 타임아웃, Swift 6 @MainActor 누락 수정

## Changes

### Multi-display fix
- `StatusBarController`: `buttonWindow.screen` fallback chain으로 패널 위치 결정

### Character animation
- `project.yml`: `Animations` 폴더를 `type: folder` sources entry로 추가 (bundle 구조 보존)
- `CharacterAnimationView`: 레거시 프레임 로드 코드 제거

### Update modal (issue #4)
- `VersionCompatibility`: 40-poll 루프 제거, "나중에" 닫기 + "업데이트 완료 → 재확인" 버튼

### Adaptive polling
- `ClaudeUsageMonitor` / `CodexUsageMonitor`: interruptible sleep (`sleepTask`), `wakeForImmediatePoll()`
- `CodexUsageMonitor`: `isInTransientBackoff` (401/403 auth error는 wake 대상 제외), `isAuthError` 플래그
- `CodexUsageMonitor.fileWatcher`: `pollOnce()` 직접 호출 → `wakeForImmediatePoll()` (이중 폴링 방지)
- `StatusBarController`: `observeTokenActivity()` — backoff 중일 때만 토큰 흐름으로 wake
- Backoff 최대값 300s → 60s

### Bug fixes
- `AppSettings`: `BucketCheck.resetId` → `String?`, nil이면 알림 skip (deduplication 오탐 방지)
- `ConnectionManager`: `runToki()` 15초 타임아웃
- `PlaylistManager`: `next()` / `previous()` `@MainActor` 추가
- `AlertManager`: `evaluateAll()` `dataProvider` `@MainActor` 추가

## Test plan
- [ ] 멀티 모니터 (상하 배치) 환경에서 패널 위치 확인
- [ ] 설정 > 캐릭터 Picker에서 rabbit 항목 표시 확인
- [ ] Claude / Codex 에러 상태에서 토큰 흐름 발생 시 즉시 재폴링 확인
- [ ] toki 버전 낮을 때 업데이트 모달 닫기 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)