### PR TITLE
fix: menu panel on wrong display in vertical multi-monitor setup (#5)

### DIFF
--- a/TokiMonitor/Presentation/MenuBar/StatusBarController.swift
+++ b/TokiMonitor/Presentation/MenuBar/StatusBarController.swift
@@ -323,11 +323,12 @@ final class StatusBarController {
         )
 
         let hostingView = NSHostingView(rootView: contentView)
-        hostingView.sizingOptions = [.minSize]
+        hostingView.sizingOptions = [.minSize, .intrinsicContentSize]
         if #available(macOS 14.0, *) {
             hostingView.safeAreaRegions = []
         }
-        hostingView.setFrameSize(hostingView.fittingSize)
+        hostingView.layoutSubtreeIfNeeded()
+        hostingView.setFrameSize(resolvedContentSize(for: hostingView))
         menuHostingView = hostingView
 
         let panel = NSPanel(
@@ -353,33 +354,50 @@ final class StatusBarController {
         panel.isFloatingPanel = true
 
         panel.contentView = hostingView
+        // Trigger layout now that the hosting view is mounted in a window —
+        // guarantees panel.frame.size reflects real SwiftUI content before we
+        // compute the origin.
+        panel.layoutIfNeeded()
 
         // Position below the clicked status item
         if let button = unit.statusItem.button,
            let buttonWindow = button.window {
-            // Convert button bounds to global screen coordinates for accurate positioning.
-            // Use button.window.screen to find the actual screen the status item is on,
-            // rather than NSScreen.main which points to the key-window screen (wrong on multi-display).
             let buttonFrame = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
-            let screen = buttonWindow.screen
+
+            // Identify the screen the user clicked on. The cursor position at
+            // click time is more reliable than button.window.screen, which can
+            // resolve to the primary display on multi-display setups.
+            let mouseLocation = NSEvent.mouseLocation
+            let screen = NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) })
+                ?? buttonWindow.screen
                 ?? NSScreen.screens.first(where: { $0.frame.contains(buttonFrame.origin) })
                 ?? NSScreen.main
             let screenFrame = screen?.visibleFrame ?? .zero
-            let contentSize = hostingView.fittingSize
 
-            // Set content size — panel auto-calculates frame including titlebar
-            panel.setContentSize(contentSize)
+            // NSHostingView.fittingSize can return (0, 0) on the first click
+            // before SwiftUI has resolved layout. A zero-sized panel inflates
+            // upward from its bottom-left origin once real content renders,
+            // pushing the visible panel off-screen (or onto an adjacent display
+            // on vertically stacked multi-monitor setups).
+            panel.setContentSize(resolvedContentSize(for: hostingView))
             let panelSize = panel.frame.size
 
-            // Align panel left edge to button left edge (standard macOS menu behavior)
             var x = buttonFrame.minX
+            if !(screenFrame.minX...screenFrame.maxX).contains(x) {
+                x = mouseLocation.x - panelSize.width / 2
+            }
             if x + panelSize.width > screenFrame.maxX {
                 x = screenFrame.maxX - panelSize.width - 4
             }
             if x < screenFrame.minX {
                 x = screenFrame.minX + 4
             }
-            let y = buttonFrame.minY - panelSize.height - 4
+
+            // Anchor below the menu bar of the clicked screen. Using
+            // screenFrame.maxY rather than buttonFrame.minY keeps the panel on
+            // the intended display even if buttonFrame reflects another screen's
+            // coordinates.
+            let y = screenFrame.maxY - panelSize.height - 4
             panel.setFrameOrigin(NSPoint(x: x, y: y))
         }
 
@@ -482,6 +500,15 @@ final class StatusBarController {
         }
         menuPanel?.close()
         menuPanel = nil
+    }
+
+    /// Resolves a non-zero content size from an NSHostingView, falling back
+    /// through fittingSize → intrinsicContentSize → current frame size. SwiftUI
+    /// layout occasionally hasn't settled on the first read, especially right
+    /// after `NSHostingView` is created.
+    private func resolvedContentSize(for hostingView: NSHostingView<MenuContentView>) -> NSSize {
+        let candidates = [hostingView.fittingSize, hostingView.intrinsicContentSize, hostingView.frame.size]
+        return candidates.first(where: { $0.width > 1 && $0.height > 1 }) ?? candidates[0]
     }
 
     private func statusItemFrame(_ unit: StatusItemUnit) -> NSRect? {


### PR DESCRIPTION
## Summary

Follow-up fix for #5. v0.2.1's screen-detection change addressed horizontal clamping but the visible symptom — panel appearing on the neighboring display in a **vertically stacked** dual-monitor setup — remained. This PR finds and fixes the actual root cause.

## Root cause

`NSHostingView.fittingSize` returns `(0, 0)` on the first click because SwiftUI has not yet resolved layout. The panel is created with zero size, so its bottom-left origin lands just below the menu-bar line — but once SwiftUI renders real content the panel inflates **upward** from that origin, pushing it off-screen or onto an adjacent display.

On a vertically stacked layout (e.g. external display above built-in), this manifests as "clicking the bottom monitor opens the panel on the top monitor". On the top monitor it inflates past the top edge entirely.

Confirmed with diagnostic logging on my local setup:
- Built-in Retina (primary, physically bottom): `(0, 0, 1710, 1112)`
- External 27" (physically top):                `(-338, 1112, 2560, 1440)`
- `hostingView.fittingSize` → `(0, 0)` on first click
- Panel `setContentSize((0,0))` → `panel.frame = (x, y, 0, 0)` with `y = screenFrame.maxY − 4`
- When SwiftUI inflated content to 272×272, the panel was drawn at Y `[y, y+272]` — well above the clicked screen.

## Fix

- Force a layout pass on `NSHostingView` via `layoutSubtreeIfNeeded()`
- Add `.intrinsicContentSize` to `sizingOptions`
- Call `panel.layoutIfNeeded()` after setting `contentView`
- Resolve the content size through a 3-stage fallback (`fittingSize → intrinsicContentSize → frame.size`), extracted into a `resolvedContentSize(for:)` helper
- Prefer `NSEvent.mouseLocation` for screen detection; fall back to `buttonWindow.screen`, then to the screen containing `buttonFrame.origin`, then to `NSScreen.main`
- Anchor Y to `screenFrame.maxY` (below the clicked screen's menu bar) rather than `buttonFrame.minY`, so the panel stays on the intended display even if `buttonFrame` reflects another screen's coordinates
- X fallback: if `buttonFrame.minX` lies outside the clicked screen, use the cursor X as the anchor

## Test plan

- [x] Verified on vertical dual-monitor setup (external above built-in, external is not primary): clicking built-in (bottom) → panel opens below built-in's menu bar; clicking external (top) → panel opens below external's menu bar
- [x] Clean build on Xcode 26.4.1 / Swift 6 / macOS 14 deployment target (Release config, arm64)
- [ ] Horizontal dual-monitor layout (no regression expected — X clamping logic unchanged for the common path)
- [ ] Single-display setup (no regression expected)

Fixes #5