### PR TITLE
fix(dashboard): make panel edit button reachable across the full card

### DIFF
--- a/TokiMonitor/Presentation/Dashboard/Panels/PanelContainerView.swift
+++ b/TokiMonitor/Presentation/Dashboard/Panels/PanelContainerView.swift
@@ -108,6 +108,12 @@ struct PanelContainerView<Content: View>: View {
             }
         }
         .padding(DS.md)
+        // Force the full padded rectangle to be hit-testable so .onHover fires
+        // anywhere inside the card — not just where chart pixels are drawn.
+        // Without this, the title bar / edit button area sits outside the
+        // hit region and the button disappears the moment the cursor leaves
+        // the drawn data, making it unreachable.
+        .contentShape(Rectangle())
         .modifier(PanelCardModifier(isHovered: isHovered))
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {


### PR DESCRIPTION
## Summary

대시보드 모든 패널(파이차트/바차트/시계열/Stat/Gauge/Table 등)에서 hover 시 떠야 할 수정(연필) 버튼이, 차트의 그려진 데이터 영역 위에서만 hover가 발화되어 사실상 클릭 불가능했던 버그를 수정합니다.

## Root cause

`PanelContainerView`의 `.onHover`가 VStack에 붙어 있었고, SwiftUI에서 VStack의 hit-test 영역은 **자식들이 실제로 그린 픽셀의 합집합**입니다:

- 차트는 데이터가 그려진 픽셀만 hit-test 가능
- title bar 우측의 spacer 영역, 패딩 영역, 차트 빈 영역은 hit-test 밖

결과: 차트 위에서 hover 켜져 edit 버튼이 표시되는데, 마우스를 그 버튼 쪽(우측 상단)으로 옮기는 순간 차트 픽셀 영역을 벗어나 hover off → 버튼 사라짐 → **수정 버튼을 누를 수 없음**.

## Fix

`.padding(DS.md)` 다음에 `.contentShape(Rectangle())` 한 줄 추가. padding이 적용된 카드 직사각형 전체가 hit-testable 영역이 되어 차트 빈 부분/패딩/title bar 어디서든 hover가 발화됩니다.

한 곳만 고치면 `PanelContainerView`를 쓰는 **모든 패널 종류**가 동시에 해결됩니다.

## Why `.contentShape(Rectangle())` is the right call

- Apple 공식 + 커뮤니티(Hacking with Swift, Swift with Majid, Use Your Loaf) 모두 권장하는 표준 패턴
- 코드베이스 내 이미 17곳에서 동일 패턴 사용 (`DashboardView`, `MenuContentView`, `PieChartView`, `BarChartPanelView` 등) — 새 패턴 도입 아님
- 부작용 없음: 자식 Button의 hit-test는 자체 영역이 우선, `PieChartView`의 slice onHover도 innermost-first dispatch로 자체 동작 유지
- CPU/메모리: hit-test가 O(자식 트리 재귀) → O(point-in-rect) 단일 검사로 미세하게 더 효율적

## Test plan

- [x] xcodebuild build: BUILD SUCCEEDED
- [ ] Default 대시보드 → 프로젝트 사용량 파이차트 → 차트 밖 영역에 hover → 수정 버튼 표시 확인
- [ ] 수정 버튼 쪽으로 마우스 이동 → 버튼 유지 + 클릭 가능 확인
- [ ] 다른 패널 타입(바차트/시계열/Stat/Gauge/Table)도 동일 동작 확인
- [ ] 패널 외부로 마우스 나가면 버튼 사라짐 확인
- [ ] 차트 내부 다른 hover 기능(파이 슬라이스 label) 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)